### PR TITLE
FFMpeg demuxer returns width instead of height

### DIFF
--- a/PyNvCodec/src/PyNvCodec.cpp
+++ b/PyNvCodec/src/PyNvCodec.cpp
@@ -375,7 +375,7 @@ uint32_t PyFFmpegDemuxer::Width() const {
 uint32_t PyFFmpegDemuxer::Height() const {
   MuxingParams params;
   upDemuxer->GetParams(params);
-  return params.videoContext.width;
+  return params.videoContext.height;
 }
 
 Pixel_Format PyFFmpegDemuxer::Format() const {


### PR DESCRIPTION
Seems like typo, ffmpeg demuxer return width inside height function