### PR TITLE
Small fix on EAGAIN and EOF handling in FFmpegDemuxer

### DIFF
--- a/PyNvCodec/TC/src/FFmpegDemuxer.cpp
+++ b/PyNvCodec/TC/src/FFmpegDemuxer.cpp
@@ -166,7 +166,7 @@ bool FFmpegDemuxer::Demux(uint8_t *&pVideo, size_t &rVideoBytes,
   }
 
   if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
-    return true;
+    return false;
   } else if (ret < 0) {
     cerr << "Failed to read frame: " << AvErrorToString(ret) << endl;
     return false;

--- a/PyNvCodec/TC/src/FFmpegDemuxer.cpp
+++ b/PyNvCodec/TC/src/FFmpegDemuxer.cpp
@@ -165,7 +165,9 @@ bool FFmpegDemuxer::Demux(uint8_t *&pVideo, size_t &rVideoBytes,
     }
   }
 
-  if (ret < 0) {
+  if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+    return true;
+  } else if (ret < 0) {
     cerr << "Failed to read frame: " << AvErrorToString(ret) << endl;
     return false;
   }


### PR DESCRIPTION
Hi! Thanks for this nice tool. 

I found that FFmpegDemuxer keeps outputing multiple EOF errors. So I fixed it according the FFmpeg official example.

https://github.com/FFmpeg/FFmpeg/blob/master/doc/examples/decode_video.c#L65-L70