### PR TITLE
Surface <-> "tensor pointer"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
 # Copyright 2019 NVIDIA Corporation
+# Copyright 2021 Kognia Sports Intelligence
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,6 +55,8 @@ if(GENERATE_PYTHON_BINDINGS)
 	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/SampleDecodeSw.py				DESTINATION bin)
 	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/SampleDecodeMultiThread.py	DESTINATION bin)
 	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/SampleEncodeMultiThread.py	DESTINATION bin)
+	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/SampleDemuxDecode.py			DESTINATION bin)
+	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/SamplePyTorch.py				DESTINATION bin)
 endif(GENERATE_PYTHON_BINDINGS)
 
 if(GENERATE_PYTORCH_EXTENSION)

--- a/PyNvCodec/inc/PyNvCodec.hpp
+++ b/PyNvCodec/inc/PyNvCodec.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 NVIDIA Corporation
+ * Copyright 2021 Kognia Sports Intelligence
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,6 +20,7 @@
 #include "Tasks.hpp"
 
 #include <chrono>
+#include <cuda.h>
 #include <cuda_runtime.h>
 #include <mutex>
 #include <pybind11/numpy.h>
@@ -76,6 +78,19 @@ public:
 
   bool DownloadSingleSurface(std::shared_ptr<Surface> surface,
                              py::array_t<uint8_t> &frame);
+};
+
+class PySurfaceFromPtr {
+  std::shared_ptr<Surface> surface;
+  Pixel_Format outputFormat;
+  uint32_t height;
+  uint32_t width;
+  uint32_t gpuID;
+
+public:
+  PySurfaceFromPtr(uint32_t width, uint32_t height, Pixel_Format format, uint32_t gpuID);
+  std::shared_ptr<Surface> Execute(CUdeviceptr ptr);
+  Pixel_Format GetFormat();
 };
 
 class PySurfaceConverter {

--- a/PyNvCodec/inc/PyNvCodec.hpp
+++ b/PyNvCodec/inc/PyNvCodec.hpp
@@ -318,7 +318,10 @@ public:
                    const py::array_t<uint8_t> &messageSEI, bool sync,
                    bool append);
 
-  bool Flush(py::array_t<uint8_t> &packets, bool all = true);
+  // Flush all the encoded frames (packets)
+  bool Flush(py::array_t<uint8_t> &packets);
+  // Flush only one encoded frame (packet)
+  bool FlushSinglePacket(py::array_t<uint8_t> &packet);
 
 private:
   bool EncodeSingleSurface(EncodeContext &ctx);

--- a/PyNvCodec/inc/PyNvCodec.hpp
+++ b/PyNvCodec/inc/PyNvCodec.hpp
@@ -296,7 +296,7 @@ public:
                    const py::array_t<uint8_t> &messageSEI, bool sync,
                    bool append);
 
-  bool Flush(py::array_t<uint8_t> &packets);
+  bool Flush(py::array_t<uint8_t> &packets, bool all = true);
 
 private:
   bool EncodeSingleSurface(EncodeContext &ctx);

--- a/PyNvCodec/inc/PyNvCodec.hpp
+++ b/PyNvCodec/inc/PyNvCodec.hpp
@@ -82,12 +82,17 @@ public:
 };
 
 class PySurfaceToPtr {
+  // Allow to copy the Surface data into a given pointer already init in gpu memory.
 public:
   PySurfaceToPtr();
+  /* Copy the Surface (surf) data into a given pointer (ptr) already init.
+   * Returns a boolean denoting if the copy was properly done.
+   */
   bool Execute(std::shared_ptr<Surface> surf, CUdeviceptr ptr);
 };
 
 class PySurfaceFromPtr {
+  // Allow to copy the data pointed by a given pointer in gpu memory inside a Surface.
   std::shared_ptr<Surface> surface;
   Pixel_Format outputFormat;
   uint32_t height;
@@ -96,6 +101,7 @@ class PySurfaceFromPtr {
 
 public:
   PySurfaceFromPtr(uint32_t width, uint32_t height, Pixel_Format format, uint32_t gpuID);
+  // Copy the data pointed by a given pointer in gpu memory (ptr) inside a Surface (return value).
   std::shared_ptr<Surface> Execute(CUdeviceptr ptr);
   Pixel_Format GetFormat();
 };

--- a/PyNvCodec/inc/PyNvCodec.hpp
+++ b/PyNvCodec/inc/PyNvCodec.hpp
@@ -80,6 +80,12 @@ public:
                              py::array_t<uint8_t> &frame);
 };
 
+class PySurfaceToPtr {
+public:
+  PySurfaceToPtr();
+  bool Execute(std::shared_ptr<Surface> surf, CUdeviceptr ptr);
+};
+
 class PySurfaceFromPtr {
   std::shared_ptr<Surface> surface;
   Pixel_Format outputFormat;

--- a/PyNvCodec/inc/PyNvCodec.hpp
+++ b/PyNvCodec/inc/PyNvCodec.hpp
@@ -129,6 +129,8 @@ public:
   PyFFmpegDemuxer(const std::string &pathToFile,
                   const std::map<std::string, std::string> &ffmpeg_options);
 
+  int Forward(int num_frames = 1);
+
   bool DemuxSinglePacket(py::array_t<uint8_t> &packet);
 
   uint32_t Width() const;
@@ -176,6 +178,8 @@ public:
   static Surface *getDecodedSurface(NvdecDecodeFrame *decoder,
                                     DemuxFrame *demuxer,
                                     bool &hw_decoder_failure, bool needSEI);
+
+  int Forward(int num_frames = 1);
 
   uint32_t Width() const;
 

--- a/PyNvCodec/src/PyNvCodec.cpp
+++ b/PyNvCodec/src/PyNvCodec.cpp
@@ -225,17 +225,11 @@ PySurfaceToPtr::PySurfaceToPtr(){}
 
 bool PySurfaceToPtr::Execute(std::shared_ptr<Surface> surf, CUdeviceptr ptr) {
   if (!surf) {
-    std::stringstream ss;
-    ss << __FUNCTION__;
-    ss << ": Source video frame has void CUDA device ptr.";
-    throw std::runtime_error(ss.str());
+    return false;
   }
 
   if (!ptr) {
-    std::stringstream ss;
-    ss << __FUNCTION__;
-    ss << ": Destination video frame has void CUDA device ptr.";
-    throw std::runtime_error(ss.str());
+    return false;
   }
 
   auto pPlane = surf->GetSurfacePlane(0U);

--- a/PyNvCodec/src/PyNvCodec.cpp
+++ b/PyNvCodec/src/PyNvCodec.cpp
@@ -1042,7 +1042,7 @@ bool PyNvEncoder::EncodeFrame(py::array_t<uint8_t> &inRawFrame,
                        messageSEI, sync, append);
 }
 
-bool PyNvEncoder::Flush(py::array_t<uint8_t> &packets) {
+bool PyNvEncoder::Flush(py::array_t<uint8_t> &packets, bool all) {
   uint32_t num_packets = 0U;
   do {
     /* Keep feeding encoder with null input until it returns zero-size
@@ -1053,8 +1053,10 @@ bool PyNvEncoder::Flush(py::array_t<uint8_t> &packets) {
       break;
     }
     num_packets++;
+    if (!all) {
+      break;
+    }
   } while (true);
-
   return (num_packets > 0U);
 }
 
@@ -1243,7 +1245,7 @@ PYBIND11_MODULE(PyNvCodec, m) {
            py::overload_cast<py::array_t<uint8_t> &, py::array_t<uint8_t> &>(
                &PyNvEncoder::EncodeFrame),
            py::arg("frame"), py::arg("packet"))
-      .def("Flush", &PyNvEncoder::Flush, py::arg("packets"));
+      .def("Flush", &PyNvEncoder::Flush, py::arg("packets"), py::arg("all") = true);
 
   py::class_<PyFfmpegDecoder>(m, "PyFfmpegDecoder")
       .def(py::init<const string &, const map<string, string> &>())

--- a/PyNvCodec/src/PyNvCodec.cpp
+++ b/PyNvCodec/src/PyNvCodec.cpp
@@ -403,22 +403,6 @@ PyFFmpegDemuxer::PyFFmpegDemuxer(const string &pathToFile,
       DemuxFrame::Make(pathToFile.c_str(), options.data(), options.size()));
 }
 
-int PyFFmpegDemuxer::Forward(int num_frames) {
-  if (num_frames < 1)
-    return 0;
-  Buffer *elementaryVideo = nullptr;
-  int i = 0;
-  for(; i < num_frames; i++) {
-    do {
-      if (TASK_EXEC_FAIL == upDemuxer->Execute()) {
-        return false;
-      }
-      elementaryVideo = (Buffer *)upDemuxer->GetOutput(0U);
-    } while (!elementaryVideo);
-  }
-  return i;
-}
-
 bool PyFFmpegDemuxer::DemuxSinglePacket(py::array_t<uint8_t> &packet) {
 
   Buffer *elementaryVideo = nullptr;
@@ -600,22 +584,6 @@ uint32_t PyNvDecoder::Width() const {
     throw runtime_error("Decoder was created without built-in demuxer support. "
                         "Please get width from demuxer instead");
   }
-}
-
-int PyNvDecoder::Forward(int num_frames) {
-  if (num_frames < 1)
-    return 0;
-  Buffer *elementaryVideo = nullptr;
-  int i = 0;
-  for(; i < num_frames; i++) {
-    do {
-      if (TASK_EXEC_FAIL == upDemuxer->Execute()) {
-        return false;
-      }
-      elementaryVideo = (Buffer *)upDemuxer->GetOutput(0U);
-    } while (!elementaryVideo);
-  }
-  return i;
 }
 
 void PyNvDecoder::LastPacketData(PacketData &packetData) const {
@@ -1413,7 +1381,6 @@ PYBIND11_MODULE(PyNvCodec, m) {
       .def(py::init<const string &>())
       .def(py::init<const string &, const map<string, string> &>())
       .def("DemuxSinglePacket", &PyFFmpegDemuxer::DemuxSinglePacket)
-      .def("Forward", &PyFFmpegDemuxer::Forward, py::arg("num_frames") = 1)
       .def("Width", &PyFFmpegDemuxer::Width)
       .def("Height", &PyFFmpegDemuxer::Height)
       .def("Format", &PyFFmpegDemuxer::Format)
@@ -1434,7 +1401,6 @@ PYBIND11_MODULE(PyNvCodec, m) {
       .def("Width", &PyNvDecoder::Width)
       .def("Height", &PyNvDecoder::Height)
       .def("LastPacketData", &PyNvDecoder::LastPacketData)
-      .def("Forward", &PyNvDecoder::Forward, py::arg("num_frames") = 1)
       .def("Framerate", &PyNvDecoder::Framerate)
       .def("Timebase", &PyNvDecoder::Timebase)
       .def("Framesize", &PyNvDecoder::Framesize)

--- a/SamplePyTorch.py
+++ b/SamplePyTorch.py
@@ -1,0 +1,123 @@
+#
+# Copyright 2021 Kognia Sports Intelligence
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import torch
+import PyNvCodec as nvc
+import PytorchNvCodec as pnvc
+import numpy as np
+import sys
+
+
+def main(gpuID, method, encFilePath, dstFilePath):
+    dstFile = open(dstFilePath, "wb")
+    nvDec = nvc.PyNvDecoder(encFilePath, gpuID)
+
+    w = nvDec.Width()
+    h = nvDec.Height()
+    res = str(w) + 'x' + str(h)
+    nvEnc = nvc.PyNvEncoder(
+        {'preset': 'hq', 'codec': 'h264', 's': res, 'bitrate' : '10M'}, gpuID)
+
+    # objects to move data between Surfaces and pointers (in this example PyTorch tensors)
+    nvFromPtr = nvc.PySurfaceFromPtr(w, h, nvc.PixelFormat.RGB, gpuID)
+    nvToPtr = nvc.PySurfaceToPtr()
+
+    # define surface converters
+    to_rgb = nvc.PySurfaceConverter(w, h, nvc.PixelFormat.NV12, nvc.PixelFormat.RGB, gpuID)
+    to_planar = nvc.PySurfaceConverter(w, h, nvc.PixelFormat.RGB, nvc.PixelFormat.RGB_PLANAR, gpuID)
+    to_yuv = nvc.PySurfaceConverter(w, h, nvc.PixelFormat.RGB, nvc.PixelFormat.YUV420, gpuID)
+    to_nv12 = nvc.PySurfaceConverter(w, h, nvc.PixelFormat.YUV420, nvc.PixelFormat.NV12, gpuID)
+
+    # There are 2 ways to convert the surface into a PyTorch tensor. Using the specific VPF pytorch extension
+    # or taking advantage of the tensor pointer. In the second case we can avoid converting to RGB_planar.
+    methods = ['PYTORCHNVCODEC', 'TOPTR_3HW', 'TOPTR_HW3']
+
+    encFrame = np.ndarray(shape=(0), dtype=np.uint8)
+    while True:
+        rawSurface = nvDec.DecodeSingleSurface()
+        if rawSurface.Empty():
+            break
+
+        # Convert to RGB interleaved
+        rgb_byte = to_rgb.Execute(rawSurface)
+
+        # Convert the rgb surface to a PyTorch tensor
+        surface_tensor: torch.Tensor
+        if method == methods[0]:
+            # Using the PytorchNvCodec module
+            # -------------------------------
+            rgb_planar = to_planar.Execute(rgb_byte)
+            surfPlane = rgb_planar.PlanePtr()
+            surface_tensor = pnvc.makefromDevicePtrUint8(
+                surfPlane.GpuMem(), surfPlane.Width(), surfPlane.Height(), surfPlane.Pitch(), surfPlane.ElemSize())
+            surface_tensor.resize_(surfPlane.Height()//h, h, w) # to 3xHxW
+        elif method == methods[1]:
+            # Direct memory mapping to tensor with shape 3HW
+            # ----------------------------------------------
+            surface_tensor = torch.zeros((3, h, w), dtype=torch.uint8,
+                                         device=torch.device(f'cuda:{gpuID}'))
+            rgb_planar = to_planar.Execute(rgb_byte)
+            nvToPtr.Execute(rgb_planar, surface_tensor.data_ptr())
+        elif method == methods[2]:
+            # Direct memory mapping to tensor with shape HW3
+            # ----------------------------------------------
+            surface_tensor = torch.zeros((h, w, 3), dtype=torch.uint8,
+                                         device=torch.device(f'cuda:{gpuID}'))
+            nvToPtr.Execute(rgb_byte, surface_tensor.data_ptr())
+            surface_tensor = surface_tensor.permute(2, 0, 1)  # to 3xHxW
+        else:
+            raise RuntimeError('invalid method')
+
+        # PROCESS YOUR TENSOR HERE
+
+        # Create surface from a PyTorch tensor
+        rawFrame = surface_tensor.permute(1, 2, 0).contiguous()  # to HxWx3
+        new_surf = nvFromPtr.Execute(rawFrame.data_ptr())
+        new_surf = to_yuv.Execute(new_surf)
+        new_surf = to_nv12.Execute(new_surf)
+        success = nvEnc.EncodeSingleSurface(new_surf, encFrame)
+        if(success):
+            encByteArray = bytearray(encFrame)
+            dstFile.write(encByteArray)
+
+    # Encoder is asynchronous, so we need to flush it
+    while True:
+        success = nvEnc.FlushSinglePacket(encFrame)
+        if(success):
+            encByteArray = bytearray(encFrame)
+            dstFile.write(encByteArray)
+        else:
+            break
+
+
+if __name__ == "__main__":
+
+    print("This sample transcode and process with pytorch an input video on given GPU.")
+    print("Usage: SamplePyTorch.py $gpu_id $to_tensor_method $input_file $output_file.")
+    print("valid to_tensor_methods:")
+    print("   PYTORCHNVCODEC: Standard approach using the VPF PyTorch extension")
+    print("   TOPTR_3HW: Direct memory mapping to PyTorch tensor with shape 3HW")
+    print("   TOPTR_HW3: Direct memory mapping to PyTorch tensor with shape HW3")
+
+
+    if(len(sys.argv) < 5):
+        print("Provide gpu ID, to_tensor_method, path to input and output files")
+        exit(1)
+
+    gpuID = int(sys.argv[1])
+    method = sys.argv[2]
+    encFilePath = sys.argv[3]
+    decFilePath = sys.argv[4]
+    main(gpuID, method, encFilePath, decFilePath)

--- a/SamplePyTorch.py
+++ b/SamplePyTorch.py
@@ -111,7 +111,6 @@ if __name__ == "__main__":
     print("   TOPTR_3HW: Direct memory mapping to PyTorch tensor with shape 3HW")
     print("   TOPTR_HW3: Direct memory mapping to PyTorch tensor with shape HW3")
 
-
     if(len(sys.argv) < 5):
         print("Provide gpu ID, to_tensor_method, path to input and output files")
         exit(1)


### PR DESCRIPTION
# Description

Added classes:
- `PySurfaceFromPtr()` allows to copy the data inside a "python pointer" into a surface
- `PySurfaceToPtr()` allows to copy the data inside a surface into a "python pointer"

<del>Added method `Forward()` in classes `PyNvDecoder` and  `PyFFmpegDemuxer ` to move forward `n` frames without decoding them. </del>

Added functionality to method `Flush()` in class `PyNvEncoder` in order to allow to flush frames one by one.

# Status

**Ready for review**
