### PR TITLE
issues_169

### DIFF
--- a/PyNvCodec/TC/inc/MemoryInterfaces.hpp
+++ b/PyNvCodec/TC/inc/MemoryInterfaces.hpp
@@ -31,6 +31,8 @@ enum Pixel_Format {
   BGR = 6,
   YCBCR = 7,
   YUV444 = 8,
+  FP32 = 9,
+  RGBFP32_PLANAR = 10,
 };
 
 /* Represents CPU-side memory.
@@ -463,6 +465,73 @@ public:
   Surface *Clone() override;
   Surface *Create() override;
 };
+
+class DllExport SurfaceFP32 : public Surface {
+public:
+    ~SurfaceFP32();
+
+    SurfaceFP32();
+    SurfaceFP32(const SurfaceFP32& other);
+    SurfaceFP32(uint32_t width, uint32_t height, CUcontext context);
+    SurfaceFP32& operator=(const SurfaceFP32& other);
+
+    Surface* Clone() override;
+    Surface* Create() override;
+
+    uint32_t Width(uint32_t planeNumber = 0U) const override;
+    uint32_t WidthInBytes(uint32_t planeNumber = 0U) const override;
+    uint32_t Height(uint32_t planeNumber = 0U) const override;
+    uint32_t Pitch(uint32_t planeNumber = 0U) const override;
+    uint32_t HostMemSize() const override;
+
+    CUdeviceptr PlanePtr(uint32_t planeNumber = 0U) override;
+    Pixel_Format PixelFormat() const override { return FP32; }
+    uint32_t NumPlanes() const override { return 1; }
+    virtual uint32_t ElemSize() const override { return sizeof(float); }
+    bool Empty() const override { return 0UL == plane.GpuMem(); }
+
+    void Update(const SurfacePlane& newPlane);
+    bool Update(SurfacePlane* pPlanes, size_t planesNum) override;
+    SurfacePlane* GetSurfacePlane(uint32_t planeNumber = 0U) override;
+
+protected:
+    SurfacePlane plane;
+};
+
+/* 32-bit planar RGB image;
+ */
+class DllExport SurfaceRGBPlanarFP32 : public Surface {
+public:
+    ~SurfaceRGBPlanarFP32();
+
+    SurfaceRGBPlanarFP32();
+    SurfaceRGBPlanarFP32(const SurfaceRGBPlanarFP32& other);
+    SurfaceRGBPlanarFP32(uint32_t width, uint32_t height, CUcontext context);
+    SurfaceRGBPlanarFP32& operator=(const SurfaceRGBPlanarFP32& other);
+
+    virtual Surface* Clone() override;
+    virtual Surface* Create() override;
+
+    uint32_t Width(uint32_t planeNumber = 0U) const override;
+    uint32_t WidthInBytes(uint32_t planeNumber = 0U) const override;
+    uint32_t Height(uint32_t planeNumber = 0U) const override;
+    uint32_t Pitch(uint32_t planeNumber = 0U) const override;
+    uint32_t HostMemSize() const override;
+
+    CUdeviceptr PlanePtr(uint32_t planeNumber = 0U) override;
+    Pixel_Format PixelFormat() const override { return RGBFP32_PLANAR; }
+    uint32_t NumPlanes() const override { return 3; }
+    virtual uint32_t ElemSize() const override { return sizeof(float); }
+    bool Empty() const override { return 0UL == plane.GpuMem(); }
+
+    void Update(const SurfacePlane& newPlane);
+    bool Update(SurfacePlane* pPlanes, size_t planesNum) override;
+    SurfacePlane* GetSurfacePlane(uint32_t planeNumber = 0U) override;
+
+protected:
+    SurfacePlane plane;
+};
+
 
 #ifdef TRACK_TOKEN_ALLOCATIONS
 /* Returns true if allocation counters are equal to zero, false otherwise;

--- a/PyNvCodec/TC/inc/NvCodecUtils.h
+++ b/PyNvCodec/TC/inc/NvCodecUtils.h
@@ -29,3 +29,5 @@ void ResizeNv12(unsigned char *dpDstNv12, int nDstPitch, int nDstWidth,
                 int nDstHeight, unsigned char *dpSrcNv12, int nSrcPitch,
                 int nSrcWidth, int nSrcHeight,
                 unsigned char *dpDstNv12UV = nullptr, cudaStream_t S = 0);
+
+void xxxkernel(const uint8_t* input, size_t sPitch, float* output, size_t dPitch, int nSrcWidth, int nSrcHeight, cudaStream_t S,float did);

--- a/PyNvCodec/TC/inc/Tasks.hpp
+++ b/PyNvCodec/TC/inc/Tasks.hpp
@@ -225,4 +225,24 @@ private:
   ResizeSurface(uint32_t width, uint32_t height, Pixel_Format format,
                 CUcontext ctx, CUstream str);
 };
+class DllExport NormalizeSurface final: public Task{
+    public:
+        NormalizeSurface() = delete;
+        NormalizeSurface(const NormalizeSurface& other) = delete;
+        NormalizeSurface& operator=(const NormalizeSurface& other) = delete;
+
+        static NormalizeSurface* Make(uint32_t width, uint32_t height,
+            float divisor, CUcontext ctx, CUstream str,Pixel_Format format);
+
+        ~NormalizeSurface();
+
+        TaskExecStatus Execute() final;
+    private:
+        static const uint32_t numInputs = 1U;
+        static const uint32_t numOutputs = 1U;
+
+        struct NormalizeSurface_Impl* pImpl;
+        NormalizeSurface(uint32_t width, uint32_t height, float divisor,CUcontext ctx, CUstream str,Pixel_Format format);
+};
+
 } // namespace VPF

--- a/PyNvCodec/TC/src/CMakeLists.txt
+++ b/PyNvCodec/TC/src/CMakeLists.txt
@@ -25,5 +25,6 @@ set(TC_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/NppCommon.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/NvCodecCliOptions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/FfmpegSwDecoder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Resize.cu
 	PARENT_SCOPE
 )

--- a/PyNvCodec/inc/PyNvCodec.hpp
+++ b/PyNvCodec/inc/PyNvCodec.hpp
@@ -298,3 +298,18 @@ public:
 private:
   bool EncodeSingleSurface(EncodeContext &ctx);
 };
+
+class PyNormalizer {
+    std::unique_ptr<NormalizeSurface> upResizer;
+    float divisor;
+    Pixel_Format outputFormat;
+    uint32_t gpuID;
+
+public:
+    PyNormalizer(uint32_t width, uint32_t height, float divisor, Pixel_Format format, uint32_t gpuID);
+
+    float Getdivisor();
+
+    std::shared_ptr<Surface> Execute(std::shared_ptr<Surface> surface);
+    Pixel_Format GetFormat();
+};

--- a/build/gocmake.sh
+++ b/build/gocmake.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Export paths to Video Codec SDK and FFMpeg
+export PATH_TO_SDK=/opt/Video_Codec_SDK_11.0.10
+export PATH_TO_FFMPEG=/opt/ffmpeg/build_x64_release_shared
+export CUDACXX=/usr/local/cuda/bin/nvcc
+export INSTALL_PREFIX=$(pwd)/install
+cmake .. \
+  -DFFMPEG_DIR:PATH="$PATH_TO_FFMPEG" \
+  -DVIDEO_CODEC_SDK_DIR:PATH="$PATH_TO_SDK" \
+  -DGENERATE_PYTHON_BINDINGS:BOOL="1" \
+  -DGENERATE_PYTORCH_EXTENSION:BOOL="0" \
+  -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.6m.so \
+  -DCMAKE_INSTALL_PREFIX:PATH="$INSTALL_PREFIX" \
+  -DCMAKE_CUDA_ARCHITECTURES:STRING="75"


### PR DESCRIPTION
add fp32Planar

```python3
to_planar = nvc.PySurfaceConverter(model_w, model_h, nvc.PixelFormat.RGB, nvc.PixelFormat.RGB_PLANAR, gpuId)
divisor = 1 / 255.
to_normail = nvc.PyNormalizer(model_w, model_h, divisor, nvc.PixelFormat.RGBFP32_PLANAR, gpuId)

...

surfPlane = to_normail.Execute(to_planar.Execute(rgbbytes)).PlanePtr()

cuda_shared_memory_set(shm_ip0_handle, surfPlane.GpuMem(), surfPlane.Width(),
                                                    surfPlane.Height(), surfPlane.Pitch())
```