### PR TITLE
fix: SampleTensorRTResnet.py, FFmpegDemuxer.cpp

### DIFF
--- a/PyNvCodec/TC/src/FFmpegDemuxer.cpp
+++ b/PyNvCodec/TC/src/FFmpegDemuxer.cpp
@@ -415,6 +415,7 @@ FFmpegDemuxer::CreateFormatContext(DataProvider *pDataProvider,
     }
   }
 
+  av_register_all();
   auto err = avformat_open_input(&ctx, nullptr, nullptr, &options);
   if (0 != err) {
     cerr << "Can't open input. Error message: " << AvErrorToString(err);
@@ -443,6 +444,7 @@ FFmpegDemuxer::CreateFormatContext(const char *szFilePath,
   }
 
   AVFormatContext *ctx = nullptr;
+  av_register_all();
   auto err = avformat_open_input(&ctx, szFilePath, nullptr, &options);
   if (err < 0) {
     cerr << "Can't open " << szFilePath << ": " << AvErrorToString(err) << "\n";

--- a/SampleTensorRTResnet.py
+++ b/SampleTensorRTResnet.py
@@ -1151,7 +1151,7 @@ class TensorRTContext:
 target_w, target_h = 224, 224
 
 def out(command):
-    result = run(command, text=True,
+    result = run(command, universal_newlines=True,
                  shell=True, stdout=PIPE, stderr=STDOUT)
     return result.stdout
 


### PR DESCRIPTION
fixed

- `ValueError: FFmpegDemuxer: no AVFormatContext provided.`: something that comes up when `av_register_all` is not called
- `Failed: TypeError: __init__() got an unexpected keyword argument 'text'`: this was the issue in `SampleTensorRTResnet.py` due to incorrect usage of `run` api of subprocess