### PR TITLE
[fix] poetry installation dockerfile

### DIFF
--- a/docker/Dockerfile-tensorrt.gpu
+++ b/docker/Dockerfile-tensorrt.gpu
@@ -15,7 +15,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     libavcodec-dev libavformat-dev libswscale-dev \
     libxvidcore-dev x264 libx264-dev libfaac-dev \
     libmp3lame-dev libtheora-dev libvorbis-dev \
-    python3.8 python3-pip python3-virtualenv && \
+    python3.8 python3.8-venv python3-pip python3-virtualenv && \
     rm -rf /var/lib/apt/lists/*
 
 # https://python-poetry.org/docs/

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -15,7 +15,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive \
     libavcodec-dev libavformat-dev libswscale-dev \
     libxvidcore-dev x264 libx264-dev libfaac-dev \
     libmp3lame-dev libtheora-dev libvorbis-dev \
-    python3.8 python3-pip python3-virtualenv && \
+    python3.8 python3.8-venv python3-pip python3-virtualenv && \
     rm -rf /var/lib/apt/lists/*
 
 # https://python-poetry.org/docs/


### PR DESCRIPTION
Hi @rarzumanyan

I found there is one APT missing to install `poetry` from dockerfile. Hope this PR will help to improve the docker image build processes.

I attached the error logs below.
```
Step 5/23 : WORKDIR $POETRY_HOME
 ---> Running in f4eee8c072bf
Removing intermediate container f4eee8c072bf
 ---> 6e14c34aefa1
Step 6/23 : RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3
 ---> Running in 381fd40319d9
The canonical source for Poetry's installation script is now https://install.python-poetry.org. Please update your usage to reflect this.
Retrieving Poetry metadata

# Welcome to Poetry!

This will download and install the latest version of Poetry,
a dependency and package manager for Python.

It will add the `poetry` command to Poetry's bin directory, located at:

/opt/poetry/bin

You can uninstall at any time by executing this script with the --uninstall option,
and these changes will be reverted.

Installing Poetry (1.1.7)
Installing Poetry (1.1.7): Creating environment
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.

    apt install python3.8-venv

You may need to use sudo with that command.  After installing the python3-venv
package, recreate your virtual environment.

Failing command: ['/opt/poetry/venv/bin/python3', '-Im', 'ensurepip', '--upgrade', '--default-pip']

The command '/bin/sh -c curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3' returned a non-zero code: 1
ERROR: Service 'vpf-tensorrt' failed to build : Build failed
```