### PR TITLE
Fix missing seek_criteria argument of decoder.seek()

### DIFF
--- a/Tests.py
+++ b/Tests.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     print('avg framerate         : ', decoder.avg_framerate())
     print('has variable framerate: ', decoder.is_vfr())
 
-    decoder.seek(7, nvc.SeekMode.PREV_KEY_FRAME)
+    decoder.seek(7, nvc.SeekMode.PREV_KEY_FRAME, nvc.SeekCriteria.BY_NUMBER)
     decoder.decode(frames_to_decode = 256, verbose=True)
     num_frames = decoder.dec_frames()
     print (str(num_frames), ' frames decoded.')
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     time.sleep(1)
 
     decoder = dec.NvDecoder(gpu_id, input, dec_file, dec.InitMode.BUILTIN)
-    decoder.seek(11, nvc.SeekMode.PREV_KEY_FRAME)
+    decoder.seek(11, nvc.SeekMode.PREV_KEY_FRAME, nvc.SeekCriteria.BY_NUMBER)
     decoder.decode(frames_to_decode = 256, verbose=True)
     num_frames = decoder.dec_frames()
     print (str(num_frames), ' frames decoded.')


### PR DESCRIPTION
Hi, 

This PR is for fixing the following error:

```
$ python build/bin/Tests.py 0 Tests/test.mp4 test.nv12 

framerate             :  30.0
avg framerate         :  30.0
has variable framerate:  False
Traceback (most recent call last):
  File "build/bin/Tests.py", line 61, in <module>
    decoder.seek(7, nvc.SeekMode.PREV_KEY_FRAME)
TypeError: seek() missing 1 required positional argument: 'seek_criteria'
```
