### PR TITLE
add av_register_all() function call back into FFmpegDemuxer.cpp

### DIFF
--- a/PyNvCodec/TC/src/FFmpegDemuxer.cpp
+++ b/PyNvCodec/TC/src/FFmpegDemuxer.cpp
@@ -463,6 +463,7 @@ FFmpegDemuxer::CreateFormatContext(const char *szFilePath,
   }
 
   AVFormatContext *ctx = nullptr;
+  av_register_all();
   auto err = avformat_open_input(&ctx, szFilePath, nullptr, &options);
   if (err < 0 || nullptr == ctx) {
     cerr << "Can't open " << szFilePath << ": " << AvErrorToString(err) << "\n";


### PR DESCRIPTION
Add `av_register_all()` function call back into "FFmpegDemuxer.cpp" to avoid error about "ValueError: FFmpegDemuxer: no AVFormatContext provided." when running `nvc.PyNvDecoder(enc_file, gpu_id)`.  Please see the issue #287 to find more details. 

PS. Function `av_register_all()`  is supported by FFMpeg v4.4 and lower version, which has been removed from branch v4.5 or master currently (reference [FFmpeg/libavfilter/allfilters.c](https://github.com/FFmpeg/FFmpeg/blob/release/4.4/libavfilter/allfilters.c)). So if you want to use newest version FFMpeg, please   notice these changes. Maybe these infomation can be add into WiKi for reference.