### PR TITLE
Use cmake variable for python executable instead of hardcoding `python`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(GENERATE_PYTORCH_EXTENSION)
 	#Extension will be built using torch.utils.cpp_extension;
 	#So we just launch python script;
 	add_custom_command(	OUTPUT Pytorch_Nv_Codec
-						COMMAND cd ${PYTORCH_EXTENSION_SOURCES_DIR} && python setup.py build --build-lib="${CMAKE_INSTALL_PREFIX}"/bin)
+						COMMAND cd ${PYTORCH_EXTENSION_SOURCES_DIR} && ${PYTHON_EXECUTABLE} setup.py build --build-lib="${CMAKE_INSTALL_PREFIX}"/bin)
 
 	add_custom_target(	PytorchNvCodec
 						DEPENDS Pytorch_Nv_Codec)


### PR DESCRIPTION
This fixes builds in environments where `python` does not point to the correct python build.