### PR TITLE
fit for remap with diffrent shape

### DIFF
--- a/PyNvCodec/TC/inc/Tasks.hpp
+++ b/PyNvCodec/TC/inc/Tasks.hpp
@@ -296,7 +296,7 @@ public:
   RemapSurface& operator=(const RemapSurface& other) = delete;
 
   static RemapSurface* Make(const float* x_map, const float* y_map,
-                             uint32_t width, uint32_t height,
+                             uint32_t remap_w, uint32_t remap_h,
                              Pixel_Format format, CUcontext ctx, CUstream str);
 
   ~RemapSurface();
@@ -309,7 +309,8 @@ private:
 
   struct RemapSurface_Impl* pImpl;
   RemapSurface(const float* x_map, const float* y_map,
-                uint32_t width, uint32_t height, Pixel_Format format,
+                uint32_t remap_w, uint32_t remap_h,
+                Pixel_Format format,
                 CUcontext ctx, CUstream str);
 };
 } // namespace VPF

--- a/PyNvCodec/inc/PyNvCodec.hpp
+++ b/PyNvCodec/inc/PyNvCodec.hpp
@@ -213,12 +213,10 @@ class PySurfaceRemaper
 
 public:
   PySurfaceRemaper(py::array_t<float>& x_map, py::array_t<float>& y_map,
-                   uint32_t width, uint32_t height, Pixel_Format format,
-                   size_t ctx, size_t str);
+                   Pixel_Format format, size_t ctx, size_t str);
 
   PySurfaceRemaper(py::array_t<float>& x_map, py::array_t<float>& y_map,
-                   uint32_t width, uint32_t height, Pixel_Format format,
-                   uint32_t gpuID);
+                   Pixel_Format format, uint32_t gpuID);
 
   Pixel_Format GetFormat();
 

--- a/PyNvCodec/src/PySurfaceRemaper.cpp
+++ b/PyNvCodec/src/PySurfaceRemaper.cpp
@@ -26,22 +26,24 @@ constexpr auto TASK_EXEC_SUCCESS = TaskExecStatus::TASK_EXEC_SUCCESS;
 constexpr auto TASK_EXEC_FAIL = TaskExecStatus::TASK_EXEC_FAIL;
 
 PySurfaceRemaper::PySurfaceRemaper(py::array_t<float>& x_map,
-                                   py::array_t<float>& y_map, uint32_t width,
-                                   uint32_t height, Pixel_Format format,
+                                   py::array_t<float>& y_map,
+                                   Pixel_Format format,
                                    size_t ctx, size_t str)
     : outputFormat(format)
 {
-  upRemaper.reset(RemapSurface::Make(x_map.data(), y_map.data(), width, height,
+  upRemaper.reset(RemapSurface::Make(x_map.data(), y_map.data(),
+                                     x_map.shape(1), x_map.shape(0),
                                      format, (CUcontext)ctx, (CUstream)str));
 }
 
 PySurfaceRemaper::PySurfaceRemaper(py::array_t<float>& x_map,
-                                   py::array_t<float>& y_map, uint32_t width,
-                                   uint32_t height, Pixel_Format format,
+                                   py::array_t<float>& y_map,
+                                   Pixel_Format format,
                                    uint32_t gpuID)
     : outputFormat(format)
 {
-  upRemaper.reset(RemapSurface::Make(x_map.data(), y_map.data(), width, height,
+  upRemaper.reset(RemapSurface::Make(x_map.data(), y_map.data(),
+                                     x_map.shape(1), x_map.shape(0),
                                      format,
                                      CudaResMgr::Instance().GetCtx(gpuID),
                                      CudaResMgr::Instance().GetStream(gpuID)));
@@ -69,10 +71,8 @@ shared_ptr<Surface> PySurfaceRemaper::Execute(shared_ptr<Surface> surface)
 void Init_PySurfaceRemaper(py::module& m)
 {
   py::class_<PySurfaceRemaper>(m, "PySurfaceRemaper")
-      .def(py::init<py::array_t<float>&, py::array_t<float>&, uint32_t,
-                    uint32_t, Pixel_Format, uint32_t>())
-      .def(py::init<py::array_t<float>&, py::array_t<float>&, uint32_t,
-                    uint32_t, Pixel_Format, size_t, size_t>())
+      .def(py::init<py::array_t<float>&, py::array_t<float>&, Pixel_Format, uint32_t>())
+      .def(py::init<py::array_t<float>&, py::array_t<float>&, Pixel_Format, size_t, size_t>())
       .def("Format", &PySurfaceRemaper::GetFormat)
       .def("Execute", &PySurfaceRemaper::Execute,
            py::return_value_policy::take_ownership,

--- a/SampleRemap.py
+++ b/SampleRemap.py
@@ -68,14 +68,14 @@ def decode(gpuID, encFilePath, remapFilePath):
 
     to_rgb = nvc.PySurfaceConverter(w, h, nvc.PixelFormat.NV12, nvc.PixelFormat.RGB, gpuID)
     cc1 = nvc.ColorspaceConversionContext(nvc.ColorSpace.BT_709, nvc.ColorRange.JPEG)
-    nv_dwn = nvc.PySurfaceDownloader(w, h, nvc.PixelFormat.RGB, gpuID)
 
     # init remaper
     remap_x, remap_y = load_remap(remapFilePath)
     remap_h, remap_w = remap_x.shape
-    assert w == remap_w
-    assert h == remap_h
-    nv_remap = nvc.PySurfaceRemaper(remap_x, remap_y, remap_w, remap_h, nvc.PixelFormat.RGB, gpuID)
+    nv_remap = nvc.PySurfaceRemaper(remap_x, remap_y, nvc.PixelFormat.RGB, gpuID)
+
+    nv_dwn = nvc.PySurfaceDownloader(remap_w, remap_h, nvc.PixelFormat.RGB, gpuID)
+
 
     dec_frame = 0
     while (dec_frame < total_num_frames):
@@ -91,7 +91,7 @@ def decode(gpuID, encFilePath, remapFilePath):
         if rgb24_remap.Empty():
             print("Remap Failed.")
             break
-        rawFrameRGB = np.ndarray(shape=(h, w, 3), dtype=np.uint8)
+        rawFrameRGB = np.ndarray(shape=(remap_h, remap_w, 3), dtype=np.uint8)
         if not nv_dwn.DownloadSingleSurface(rgb24_remap, rawFrameRGB):
             print("DownloadSingleSurface Failed.")
             break


### PR DESCRIPTION
A new feature update:

1. The shape of remap array can be different from the original image. The width and height of the resulting graph are equal to the remap array, and the channel is equal to the original graph

2. The width and height of remap array can be read from the input numpy array. So the initialization of PySurfaceRemaper becomes simpler


