### PR TITLE
Reduce decoder latency by 2 frames

### DIFF
--- a/PyNvCodec/TC/src/NvDecoder.cpp
+++ b/PyNvCodec/TC/src/NvDecoder.cpp
@@ -614,6 +614,8 @@ NvDecoder::NvDecoder(CUstream cuStream, CUcontext cuContext,
                      cudaVideoCodec eCodec, bool bLowLatency, int maxWidth,
                      int maxHeight)
 {
+  bLowLatency = true;
+
   p_impl = new NvDecoderImpl();
   p_impl->m_cuvidStream = cuStream;
   p_impl->m_cuContext = cuContext;
@@ -716,6 +718,7 @@ bool NvDecoder::DecodeLockSurface(Buffer const* encFrame,
       encFrame ? encFrame->GetDataAs<const unsigned char>() : nullptr;
   packet.payload_size = encFrame ? encFrame->GetRawMemSize() : 0U;
   packet.flags = CUVID_PKT_TIMESTAMP;
+  packet.flags |= CUVID_PKT_ENDOFPICTURE;
   packet.timestamp = pdata.pts;
   if (!decCtx.no_eos &&
       (nullptr == packet.payload || 0 == packet.payload_size)) {


### PR DESCRIPTION
I'm not sure this is a target of this project, but this reduces my latency on a 20fps stream from 110ms down to 10ms.

I tried adding flags to the abstraction layers, but they are so deep! I understand you may not always want these.