### PR TITLE
multiple nf for pyffmpegdecoder

### DIFF
--- a/PyNvCodec/TC/inc/Tasks.hpp
+++ b/PyNvCodec/TC/inc/Tasks.hpp
@@ -137,6 +137,7 @@ public:
 
   TaskExecStatus Run() final;
   TaskExecStatus GetSideData(AVFrameSideDataType);
+  void GetParams(MuxingParams& params);
 
   ~FfmpegDecodeFrame() final;
   static FfmpegDecodeFrame* Make(const char* URL,

--- a/PyNvCodec/inc/PyNvCodec.hpp
+++ b/PyNvCodec/inc/PyNvCodec.hpp
@@ -264,16 +264,36 @@ public:
 
 class PyFfmpegDecoder {
   std::unique_ptr<FfmpegDecodeFrame> upDecoder = nullptr;
+  std::unique_ptr<PyFrameUploader> upUploader = nullptr;
 
   void *GetSideData(AVFrameSideDataType data_type, size_t &raw_size);
 
+  uint32_t last_w;
+  uint32_t last_h;
+  uint32_t gpu_id;
+
+  void UpdateState();
+  bool IsResolutionChanged();
+
+  void UploaderLazyInit();
+
 public:
   PyFfmpegDecoder(const std::string &pathToFile,
-                  const std::map<std::string, std::string> &ffmpeg_options);
+                  const std::map<std::string, std::string> &ffmpeg_options,
+                  uint32_t gpuID);
 
   bool DecodeSingleFrame(py::array_t<uint8_t> &frame);
+  std::shared_ptr<Surface> DecodeSingleSurface();
 
   py::array_t<MotionVector> GetMotionVectors();
+
+  uint32_t Width() const;
+  uint32_t Height() const;
+  double Framerate() const;
+  ColorSpace Color_Space() const;
+  ColorRange Color_Range() const;
+  cudaVideoCodec Codec() const;
+  Pixel_Format PixelFormat() const;
 };
 
 class PyNvDecoder {
@@ -283,6 +303,12 @@ class PyNvDecoder {
   uint32_t gpuID;
   static uint32_t const poolFrameSize = 4U;
   Pixel_Format format;
+
+  uint32_t last_w;
+  uint32_t last_h;
+
+  void UpdateState();
+  bool IsResolutionChanged();
 
 public:
   PyNvDecoder(uint32_t width, uint32_t height, Pixel_Format format,


### PR DESCRIPTION
Multiple new features for `PyFfmpegDecoder` class:

- `DecodeSingleSurface` method which decodes frame using fallback CPU decoder and uploads it to GPU memory
- All sorts of getter methods for width, height, format etc.