### PR TITLE
Compile errors due to int -> enum cast

### DIFF
--- a/PyNvCodec/TC/src/NvCodecCliOptions.cpp
+++ b/PyNvCodec/TC/src/NvCodecCliOptions.cpp
@@ -1302,10 +1302,10 @@ void NvEncoderClInterface::SetupVuiConfig(
   if (!is_reconfigure) {
     memset(&params, 0, sizeof(params));
 
-    params.videoFormat = 5;
-    params.colourPrimaries = 2;
-    params.transferCharacteristics = 2;
-    params.colourMatrix = 2;
+    params.videoFormat = NV_ENC_VUI_VIDEO_FORMAT_UNSPECIFIED;
+    params.colourPrimaries = NV_ENC_VUI_COLOR_PRIMARIES_UNSPECIFIED;
+    params.transferCharacteristics = NV_ENC_VUI_TRANSFER_CHARACTERISTIC_UNSPECIFIED;
+    params.colourMatrix = NV_ENC_VUI_MATRIX_COEFFS_UNSPECIFIED;
   }
 
   if (print_settings) {

--- a/PyNvCodec/src/PyFFMpegDecoder.cpp
+++ b/PyNvCodec/src/PyFFMpegDecoder.cpp
@@ -123,7 +123,7 @@ py::array_t<MotionVector> PyFfmpegDecoder::GetMotionVectors()
   size /= sizeof(*ptr);
 
   if (ptr && size) {
-    py::array_t<MotionVector> mv({size});
+    py::array_t<MotionVector> mv({static_cast<int64_t>(size)});
     auto req = mv.request(true);
     auto mvc = static_cast<MotionVector*>(req.ptr);
 


### PR DESCRIPTION
I replaced the int values with the respective enum values. This removes compile errror and also increases readability.
Closes #391 