### PR TITLE
Removed python development lib dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(GENERATE_PYTHON_BINDINGS)
 endif(GENERATE_PYTHON_BINDINGS)
 
 if(GENERATE_PYTORCH_EXTENSION)
-	find_package(Python3 3.6 REQUIRED COMPONENTS Interpreter Development)
+	find_package(Python3 3.6 REQUIRED COMPONENTS Interpreter Development.Module)
 
 	#Extension will be built using torch.utils.cpp_extension;
 	#So we just launch python script;

--- a/PyNvCodec/CMakeLists.txt
+++ b/PyNvCodec/CMakeLists.txt
@@ -45,7 +45,7 @@ include_directories(${inc_dir})
 set(GENERATE_PYTHON_BINDINGS FALSE CACHE BOOL "Generate VPF Python bindings")
 
 if(GENERATE_PYTHON_BINDINGS)
-	find_package(Python3 3.6 REQUIRED COMPONENTS Interpreter Development)
+	find_package(Python3 3.6 REQUIRED COMPONENTS Interpreter Development.Module)
 	if(Python3_FOUND)
 		#Adding pybind11 stuff;
 		include(FetchContent)
@@ -57,11 +57,11 @@ if(GENERATE_PYTHON_BINDINGS)
 		FetchContent_MakeAvailable(pybind11)
 
 		#Add target;
-		pybind11_add_module(PyNvCodec SHARED ${PYNVCODEC_SOURCES} ${PYNVCODEC_HEADERS})
+		pybind11_add_module(PyNvCodec MODULE ${PYNVCODEC_SOURCES} ${PYNVCODEC_HEADERS})
 		set_property(TARGET PyNvCodec PROPERTY CXX_STANDARD 14)
 		
 		#Link libs;
-		target_link_libraries(PyNvCodec PUBLIC TC_CORE TC ${Python3_LIBRARIES} ${NVCUVID_LIBRARY} ${NVENCODE_LIBRARY})
+		target_link_libraries(PyNvCodec PUBLIC TC_CORE TC ${NVCUVID_LIBRARY} ${NVENCODE_LIBRARY})
 	endif(Python3_FOUND)
 endif(GENERATE_PYTHON_BINDINGS)
 


### PR DESCRIPTION
**Background:**
I was having trouble using this extension outside of a development context because of the wide range of dependencies needed to build/use it. Unfortunately the docker image was not a viable solution in my specific case. So Instead I tried packing the extension inside a .whl file however, this didn't work out of the box since the extension is explicitly linking to `libpython3.x.so`

**This change:**
- Removes the `libpython3.x.so` dependency from the generated PyNvCodec so file. (no longer required to install `python3.x-dev` on machine)
- When using the extension, it will use the python interpreter from your environment instead of linking to the libpython3.x.so file.
- Allows this extension to be packed in a wheel package using a Cuda enabled manylinux image. (more info: https://peps.python.org/pep-0513/#libpythonx-y-so-1)

**Drawback:**
- No longer allows you to use the extension outside of a python environment.

**Alternative implementation:**
- Introduce a new Cmake variable to build the extension as MODULE instead of SHARED
- To ensure compatibility with current users the default value of the build variable could be set to "SHARED"  (although I personally think MODULE is a better default)