### PR TITLE
Enable VP8 decoding

### DIFF
--- a/src/PyNvCodec/src/PyNvCodec.cpp
+++ b/src/PyNvCodec/src/PyNvCodec.cpp
@@ -253,6 +253,7 @@ PYBIND11_MODULE(_PyNvCodec, m)
       .value("H264", cudaVideoCodec::cudaVideoCodec_H264)
       .value("HEVC", cudaVideoCodec::cudaVideoCodec_HEVC)
       .value("VP9", cudaVideoCodec::cudaVideoCodec_VP9)
+      .value("VP8", cudaVideoCodec::cudaVideoCodec_VP8)
       .export_values();
 
   py::enum_<SeekMode>(m, "SeekMode")


### PR DESCRIPTION
By exposing the codec type "VP8" to the python side the decoding seems to work fine for VP8. I'm not sure if this was disabled on purpose, but I am interested if there was a reason.