### PR TITLE
Fix configure failure using older cmake than 3.25

### DIFF
--- a/src/TC/CMakeLists.txt
+++ b/src/TC/CMakeLists.txt
@@ -141,7 +141,7 @@ if(PKG_CONFIG_FOUND AND (NOT WIN32)) # pkgconfig works on Windows, but can not h
         libavutil>=56.31.100
     )
     target_link_libraries(TC_CORE PUBLIC PkgConfig::LIBAV)
-    try_compile(HAS_BSF SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/has_bsf_compile_test.c LINK_LIBRARIES PkgConfig::LIBAV)
+    try_compile(HAS_BSF ${PROJECT_BINARY_DIR} SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/has_bsf_compile_test.c LINK_LIBRARIES PkgConfig::LIBAV)
 else()
     set(TC_FFMPEG_INCLUDE_DIR "" CACHE PATH "Where to find ffmpeg includes")
     set(TC_FFMPEG_LIBRARY_DIR "" CACHE PATH "Where to find ffmpeg libraries")


### PR DESCRIPTION
This pull request is that try_compile can support older cmake than 3.25.

The syntax of try_compile without `<bindir>`  requires newer cmake than 3.25, but this project allows cmake 3.21 or later, so versions is inconsistent.

In venv with include-system-site-packages=true and older cmake whl than 3.25 in the system, the following error occurs.
For example, I faced this error when using venv with include-system-site-packages=true in nvcr.io/nvidia/pytorch:23.05-py3 ngc container.

```
$ pip3 install git+https://github.com/NVIDIA/VideoProcessingFramework
...
      CMake Error: The source directory "SOURCES/CMakeFiles/CMakeTmp" does not exist.
      Specify --help for usage, or press the help button on the CMake GUI.
      CMake Error at src/TC/CMakeLists.txt:144 (try_compile):
        Failed to configure test project build system.
```