### PR TITLE
Add support for gray16 and export gray12-16 to py

### DIFF
--- a/src/PyNvCodec/src/PyNvCodec.cpp
+++ b/src/PyNvCodec/src/PyNvCodec.cpp
@@ -235,6 +235,8 @@ PYBIND11_MODULE(_PyNvCodec, m)
       .value("YUV422", Pixel_Format::YUV422)
       .value("P10", Pixel_Format::P10)
       .value("P12", Pixel_Format::P12)
+      .value("GRAY12", Pixel_Format::GRAY12)
+      .value("GRAY16", Pixel_Format::GRAY16)
       .export_values();
 
   py::enum_<ColorSpace>(m, "ColorSpace")

--- a/src/TC/inc/MemoryInterfaces.hpp
+++ b/src/TC/inc/MemoryInterfaces.hpp
@@ -46,6 +46,7 @@ enum Pixel_Format {
   YUV420_10bit = 15,
   NV12_Planar = 16,
   GRAY12 = 17,
+  GRAY16 = 18,
 };
 
 enum ColorSpace {


### PR DESCRIPTION
I'm working with depth and gray16 is easily supported by vpf. Gray16 same as Gray12 code. Also python PixelFormat did not include new formats and now they do. 