### PR TITLE
Fix:  function SetupNppContext did not Pop CUDA Context

### DIFF
--- a/src/TC/src/NppCommon.cpp
+++ b/src/TC/src/NppCommon.cpp
@@ -1,4 +1,5 @@
 #include "NppCommon.hpp"
+#include "MemoryInterfaces.hpp"
 #include <cstring>
 #include <iostream>
 #include <mutex>
@@ -12,7 +13,7 @@ void SetupNppContext(CUcontext context, CUstream stream,
   memset(&nppCtx, 0, sizeof(nppCtx));
 
   lock_guard<mutex> lock(gNppMutex);
-  cuCtxPushCurrent(context);
+  CudaCtxPush ctxPush(context);
 
   CUdevice device;
   auto res = cuCtxGetDevice(&device);


### PR DESCRIPTION
 Causing the original cuda context not to be restored after the construction of the PySurfaceConverter object